### PR TITLE
refactor: use proper variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ None.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
-
-some possible values for `scaling_governor` can be found [here](https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#generic-scaling-governors)
+| **Variable Name**     | **Type**| **Default Value**| **Description**|
+| :---------------------| :------:| :---------------:| :--------------|
+| cpu_scaling_governor: | string  | "performance"    | the cpu scaling governor to use some possible values can be found [here](https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html#generic-scaling-governors).|
 
 ## Dependencies
 
@@ -21,7 +21,9 @@ None.
 ```yaml
 - hosts: all
   roles:
-    - tinyblargon.cpu_scaling_governor
+    - Tinyblargon.cpu_scaling_governor
+      vars:
+        cpu_scaling_governor: "performance"
 ```
 
 ## License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
-scaling_governor: "performance"
+cpu_scaling_governor: "performance"
+
+# Legacy
+scaling_governor: ""

--- a/templates/scaling-governor.service.j2
+++ b/templates/scaling-governor.service.j2
@@ -1,9 +1,9 @@
 [Unit]
-Description=set the cpu scaling_governor to {{ scaling_governor }}
+Description=set the cpu scaling_governor to {{ cpu_scaling_governor_used }}
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c "echo '{{ scaling_governor }}' | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor"
+ExecStart=/bin/bash -c "echo '{{ cpu_scaling_governor_used }}' | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor"
 StandardOutput=journal
 
 [Install]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,3 @@
+---
+cpu_scaling_governor_used: >-
+  {{ scaling_governor if scaling_governor != "" else cpu_scaling_governor }}


### PR DESCRIPTION
Used the proper naming convention for the scaling governor variable, while keeping it backwards compatible with the old name.
The old variable will overwrite the new one when the one isn't empty.