### PR TITLE
Fix formatting of cpu_scaling_governor_service_file_location

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 cpu_scaling_governor_service_name: "scaling-governor.service"
-cpu_scaling_governor_service_file_location: >-
-  "/etc/systemd/system/{{ cpu_scaling_governor_service_name }}"
+cpu_scaling_governor_service_file_location: "/etc/systemd/system/{{ cpu_scaling_governor_service_name }}"


### PR DESCRIPTION
Fix #8.

Currently in more recent versions of ansible, the role crashes with this error
```
fatal: [pve03]: FAILED! => {"changed": false, "checksum": "0787bdbaf904b42f43df7d6e24d4af155d3f0e28", "msg": "Destination directory \"/etc/systemd/system does not exist"}
```
Removing the scalar expression works properly